### PR TITLE
add encoding utf-8

### DIFF
--- a/encode_bpe.py
+++ b/encode_bpe.py
@@ -102,9 +102,9 @@ if __name__=='__main__':
     parser.add_argument("--combine", help="Concatenate files with <|endoftext|> separator into chunks of this minimum size", type=int, default=50000 )
     args = parser.parse_args()
 
-    with open('ja-bpe.txt') as f:
+    with open('ja-bpe.txt', encoding='utf-8') as f:
         bpe = f.read().split('\n')
-    with open('emoji.json') as f:
+    with open('emoji.json', encoding='utf-8') as f:
         emoji = json.loads(f.read())
     enc = BPEEncoder_ja(bpe, emoji)
 
@@ -119,7 +119,7 @@ if __name__=='__main__':
             for file in tqdm(files):
                 if file.endswith(".txt"):
                     input = os.path.join(curDir, file)
-                    with open(input, 'r') as fp:
+                    with open(input, 'r', encoding='utf-8') as fp:
                         raw_text += fp.read()
                     raw_text += '<|endoftext|>'
                     if len(raw_text) >= args.combine:
@@ -129,7 +129,7 @@ if __name__=='__main__':
             if raw_text and len(raw_text) > 0:
                 tokens = np.stack(enc.encode(raw_text))
                 token_chunks.append(tokens)
-        with open('tmp%d.pkl'%i, 'wb') as f:
+        with open('tmp%d.pkl'%i, 'wb', encoding='utf-8') as f:
             pickle.dump(token_chunks, f)
 
     for curDir, dirs, files in os.walk(args.src_dir):
@@ -140,7 +140,7 @@ if __name__=='__main__':
 
     token_chunks = []
     for i in range(args.num_process):
-        with open('tmp%d.pkl'%i, 'rb') as f:
+        with open('tmp%d.pkl'%i, 'rb', encoding='utf-8') as f:
             token_chunks.extend(pickle.load(f))
 
     np.savez_compressed(args.dst_file, *token_chunks)

--- a/gpt2-generate.py
+++ b/gpt2-generate.py
@@ -25,17 +25,17 @@ parser.add_argument('--max_length', type=int, default=500)
 parser.add_argument('--min_length', type=int, default=0)
 args = parser.parse_args()
 
-with open('ja-bpe.txt') as f:
+with open('ja-bpe.txt', encoding='utf-8') as f:
     bpe = f.read().split('\n')
 
-with open('emoji.json') as f:
+with open('emoji.json', encoding='utf-8') as f:
     emoji = json.loads(f.read())
 
 enc = BPEEncoder_ja(bpe, emoji)
 n_vocab = len(enc)
 
 if os.path.isfile(args.model+'/hparams.json'):
-    with open(args.model+'/hparams.json') as f:
+    with open(args.model+'/hparams.json', encoding='utf-8') as f:
         params = json.loads(f.read())
         hparams = HParams(**params)
 elif 'small' in args.model:
@@ -113,7 +113,7 @@ with tf.Session(config=config,graph=tf.Graph()) as sess:
     saver.restore(sess, ckpt)
 
     if len(args.output_file) > 0:
-        with open(args.output_file, 'w') as of:
+        with open(args.output_file, 'w', encoding='utf-8') as of:
             for i in range(args.num_generate):
                 of.write(generate_one(sess, output)+'\n')
                 if i < args.num_generate-1:

--- a/gpt2-score.py
+++ b/gpt2-score.py
@@ -52,17 +52,17 @@ parser.add_argument('--exclude-end', action='store_true')
 parser.add_argument('--gpu', type=str, default='0')
 args = parser.parse_args()
 
-with open('ja-bpe.txt') as f:
+with open('ja-bpe.txt', encoding='utf-8') as f:
     bpe = f.read().split('\n')
 
-with open('emoji.json') as f:
+with open('emoji.json', encoding='utf-8') as f:
     emoji = json.loads(f.read())
 
 enc = BPEEncoder_ja(bpe, emoji)
 n_vocab = len(enc)
 
 if os.path.isfile(args.model+'/hparams.json'):
-    with open(args.model+'/hparams.json') as f:
+    with open(args.model+'/hparams.json', encoding='utf-8') as f:
         params = json.loads(f.read())
         hparams = HParams(**params)
 elif 'small' in args.model:

--- a/gpt2-transform.py
+++ b/gpt2-transform.py
@@ -18,17 +18,17 @@ parser.add_argument('--context', type=str, required=True)
 parser.add_argument('--gpu', type=str, default='0')
 args = parser.parse_args()
 
-with open('ja-bpe.txt') as f:
+with open('ja-bpe.txt', encoding='utf-8') as f:
     bpe = f.read().split('\n')
 
-with open('emoji.json') as f:
+with open('emoji.json', encoding='utf-8') as f:
     emoji = json.loads(f.read())
 
 enc = BPEEncoder_ja(bpe, emoji)
 n_vocab = len(enc)
 
 if os.path.isfile(args.model+'/hparams.json'):
-    with open(args.model+'/hparams.json') as f:
+    with open(args.model+'/hparams.json', encoding='utf-8') as f:
         params = json.loads(f.read())
         hparams = HParams(**params)
 elif 'small' in args.model:

--- a/run_finetune.py
+++ b/run_finetune.py
@@ -42,10 +42,10 @@ def maketree(path):
     except:
         pass
 
-with open('ja-bpe.txt') as f:
+with open('ja-bpe.txt', encoding='utf-8') as f:
     bpe = f.read().split('\n')
 
-with open('emoji.json') as f:
+with open('emoji.json', encoding='utf-8') as f:
     emoji = json.loads(f.read())
 
 enc = BPEEncoder_ja(bpe, emoji)
@@ -55,7 +55,7 @@ def main():
     args = parser.parse_args()
 
     if os.path.isfile(args.base_model+'/hparams.json'):
-        with open(args.base_model+'/hparams.json') as f:
+        with open(args.base_model+'/hparams.json', encoding='utf-8') as f:
             params = json.loads(f.read())
             hparams = HParams(**params)
     elif 'small' in args.base_model:
@@ -182,7 +182,7 @@ def main():
         if os.path.exists(counter_path):
             # Load the step number if we're resuming a run
             # Add 1 so we don't immediately try to save again
-            with open(counter_path, 'r') as fp:
+            with open(counter_path, 'r', encoding='utf-8') as fp:
                 counter = int(fp.read()) + 1
 
         maketree(os.path.join(CHECKPOINT_DIR, args.run_name))
@@ -197,9 +197,9 @@ def main():
                 sess,
                 os.path.join(CHECKPOINT_DIR, args.run_name, 'model'),
                 global_step=counter)
-            with open(counter_path, 'w') as fp:
+            with open(counter_path, 'w', encoding='utf-8') as fp:
                 fp.write(str(counter) + '\n')
-            with open(hparams_path, 'w') as fp:
+            with open(hparams_path, 'w', encoding='utf-8') as fp:
                 fp.write(json.dumps({
                       "n_vocab": int(hparams.n_vocab),
                       "n_ctx": int(hparams.n_ctx),


### PR DESCRIPTION
It works fine on mac, but on windows, it's as follows.
```
Traceback (most recent call last):
  File "gpt2-generate.py", line 29, in <module>
    bpe = f.read().split('\n')
UnicodeDecodeError: 'cp932' codec can't decode byte 0x99 in position 29: illegal multibyte sequence
```